### PR TITLE
Fix: Remove .js extension from import

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,5 +1,5 @@
 import { VercelRequest, VercelResponse } from '@vercel/node';
-import app from './src/server.js';  // Cambiado de '../api/src/server.js' a './src/server.js'
+import app from './src/server';
 
 export default function handler(req: VercelRequest, res: VercelResponse) {
   console.log('API called:', req.method, req.url);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed `.js` extension from import statement in `api/index.ts`

- Ensures compatibility with TypeScript and module resolution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove .js extension from import statement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/index.ts

<li>Changed import statement to remove <code>.js</code> extension<br> <li> Ensures proper module resolution in TypeScript environment


</details>


  </td>
  <td><a href="https://github.com/Madadeivi/Intranet/pull/29/files#diff-e20f6a321b0e83ca7f3c3b778efc3f41e67928c93b59675f06fed2e70fb9becd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>