### PR TITLE
Fix: Remove .js extensions from imports

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -4,8 +4,8 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 
-import routes from './src/routes/index.js';
-import { errorHandler } from './src/middleware/errorHandler.js';
+import routes from './src/routes/index';
+import { errorHandler } from './src/middleware/errorHandler';
 
 const app = express();
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed `.js` extensions from import statements in `api/index.ts`

- Ensures compatibility with TypeScript module resolution


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove .js extensions from imports in index.ts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

api/index.ts

<li>Removed <code>.js</code> extensions from two import statements<br> <li> Updated imports for routes and errorHandler to extensionless paths


</details>


  </td>
  <td><a href="https://github.com/Madadeivi/Intranet/pull/32/files#diff-e20f6a321b0e83ca7f3c3b778efc3f41e67928c93b59675f06fed2e70fb9becd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>